### PR TITLE
Update requirements for bs5

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ckanext-scheming==3.0.0
 -e git+https://github.com/depositar/ckanext-geoview.git#egg=ckanext-geoview
 -e git+https://github.com/depositar/ckanext-wikidatakeyword.git#egg=ckanext-wikidatakeyword
 -e git+https://github.com/ckan/ckanext-dcat.git@v1.5.1#egg=ckanext-dcat
-git+https://github.com/ckan/ckanext-showcase.git@v1.6.1#egg=ckanext-showcase
+git+https://github.com/ckan/ckanext-showcase.git@v1.8.3#egg=ckanext-showcase
 git+https://github.com/ckan/ckanext-pdfview.git@0.0.8#egg=ckanext-pdfview
 -e git+https://github.com/depositar/ckanext-depositar_theme.git#egg=ckanext-depositar_theme
 git+https://github.com/depositar/ckanext-citation.git#egg=ckanext-citation

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ckanext-scheming==3.0.0
 -e git+https://github.com/depositar/ckanext-geoview.git#egg=ckanext-geoview
 -e git+https://github.com/depositar/ckanext-wikidatakeyword.git#egg=ckanext-wikidatakeyword
 -e git+https://github.com/ckan/ckanext-dcat.git@v1.5.1#egg=ckanext-dcat
-git+https://github.com/ckan/ckanext-showcase.git@v1.5.2#egg=ckanext-showcase
+git+https://github.com/ckan/ckanext-showcase.git@v1.6.1#egg=ckanext-showcase
 git+https://github.com/ckan/ckanext-pdfview.git@0.0.8#egg=ckanext-pdfview
 -e git+https://github.com/depositar/ckanext-depositar_theme.git#egg=ckanext-depositar_theme
 git+https://github.com/depositar/ckanext-citation.git#egg=ckanext-citation


### PR DESCRIPTION
Upgrade [ckanext-showcase](https://github.com/ckan/ckanext-showcase) to atleast [1.6.1](https://github.com/ckan/ckanext-showcase/releases/tag/v1.6.1) for bs5